### PR TITLE
Fix get_im_channel - Change im.open by conversations.open

### DIFF
--- a/errbot_slack_bolt_backend/slackbolt.py
+++ b/errbot_slack_bolt_backend/slackbolt.py
@@ -635,7 +635,7 @@ class SlackBoltBackend(ErrBot):
     def get_im_channel(self, id_):
         """Open a direct message channel to a user"""
         try:
-            response = self.webclient.im_open(user=id_)
+            response = self.webclient.conversations_open(users=id_)
             return response["channel"]["id"]
         except SlackAPIResponseError as e:
             if e.error == "cannot_dm_bot":

--- a/errbot_slack_bolt_backend/slackbolt.py
+++ b/errbot_slack_bolt_backend/slackbolt.py
@@ -593,12 +593,12 @@ class SlackBoltBackend(ErrBot):
         name = name.lstrip("#")
         channel = [
             channel
-            for channel in self.webclient.channels_list()
-            if channel.name == name
+            for channel in self.webclient.conversations_list()["channels"]
+            if channel["name"] == name
         ]
         if not channel:
             raise RoomDoesNotExistError(f"No channel named {name} exists")
-        return channel[0].id
+        return channel[0]["id"]
 
     def channels(self, exclude_archived=True, joined_only=False):
         """


### PR DESCRIPTION
Fixes error when starting [AccessBot](https://github.com/strongdm/accessbot)

```
11:12:45 ERROR    errbot.plugin_manager     Error loading AccessBot.
Traceback (most recent call last):
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/errbot/plugin_manager.py", line 521, in activate_plugin
    self._activate_plugin(plugin, plugin_info)
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/errbot/plugin_manager.py", line 474, in _activate_plugin
    plugin.activate()
  File "plugins/sdm/accessbot.py", line 26, in activate
    poller_helper = self.get_poller_helper()
  File "plugins/sdm/accessbot.py", line 109, in get_poller_helper
    return PollerHelper(self)
  File "plugins/sdm/lib/poller_helper.py", line 6, in __init__
    self.__admin_ids = bot.get_admin_ids()
  File "plugins/sdm/accessbot.py", line 118, in get_admin_ids
    return [self.build_identifier(admin) for admin in self.get_admins()]
  File "plugins/sdm/accessbot.py", line 118, in <listcomp>
    return [self.build_identifier(admin) for admin in self.get_admins()]
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/errbot/botplugin.py", line 691, in build_identifier
    return self._bot.build_identifier(txtrep)
  File "errbot-slack-bolt-backend/errbot_slack_bolt_backend/slackbolt.py", line 969, in build_identifier
    return SlackPerson(self.webclient, userid, self.get_im_channel(userid))
  File "errbot-slack-bolt-backend/errbot_slack_bolt_backend/slackbolt.py", line 639, in get_im_channel
    response = self.webclient.im_open(user = id_)
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/slack_sdk/web/client.py", line 1887, in im_open
    return self.api_call("im.open", json=kwargs)
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/slack_sdk/web/base_client.py", line 135, in api_call
    return self._sync_send(api_url=api_url, req_args=req_args)
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/slack_sdk/web/base_client.py", line 171, in _sync_send
    return self._urllib_api_call(
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/slack_sdk/web/base_client.py", line 303, in _urllib_api_call
    return SlackResponse(
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/slack_sdk/web/slack_response.py", line 204, in validate
    raise e.SlackApiError(message=msg, response=self)
slack_sdk.errors.SlackApiError: The request to the Slack API failed.
The server responded with: {'ok': False, 'error': 'method_deprecated', 'response_metadata': {'messages': ['[ERROR] This method is retired and can no longer be used. Please use conversations.open instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.']}}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/errbot/plugin_manager.py", line 433, in activate_non_started_plugins
    self.activate_plugin(name)
  File "/Users/rodolfo.campos/sdm/github/accessbot/venv/lib/python3.9/site-packages/errbot/plugin_manager.py", line 527, in activate_plugin
    raise PluginActivationException(f"{name} failed to start : {e}.")
errbot.plugin_manager.PluginActivationException: AccessBot failed to start : The request to the Slack API failed.
The server responded with: {'ok': False, 'error': 'method_deprecated', 'response_metadata': {'messages': ['[ERROR] This method is retired and can no longer be used. Please use conversations.open instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api.']}}.
```